### PR TITLE
Update stashcreds function to use Add-Content

### DIFF
--- a/RunAs/readme.md
+++ b/RunAs/readme.md
@@ -12,7 +12,12 @@ $mycreds = New-Object Management.Automation.PSCredential('domain\username', (Con
 # handy function to do it for you..
 function stashcreds ($var) {
     $cred = Get-Credential
-    [IO.File]::AppendAllText($profile, "`n`$$var = New-Object Management.Automation.PSCredential('$($cred.Username)', (ConvertTo-SecureString '$(ConvertFrom-SecureString $cred.Password)'))`n")
+    If ($cred.Password.Length -eq 0) {
+        Write-Host "ERROR: No password provided. Credentials were not saved!" -ForegroundColor Red
+        Exit 1
+    }
+    $content = "`n`$$var = New-Object Management.Automation.PSCredential('$($cred.Username)', (ConvertTo-SecureString '$(ConvertFrom-SecureString $cred.Password)'))`n"
+    Add-Content -Encoding Ascii -Path $profile -Value $content
 }
 ```
 


### PR DESCRIPTION
* Also added a check to prevent the user from saving credentials with an empty password which would break the user's profile and cause errors to appear every time a user opens PS. 